### PR TITLE
Merge develop to master

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,8 +19,6 @@ jobs:
           release-type: node
           package-name: line-highlighter
           target-branch: master
-          pull-request-title-pattern: "Release v${version}"
-          pull-request-header: "Release Notes"
           
       # The following steps only run if a release was created
       - uses: actions/checkout@v3

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -18,7 +18,9 @@
       ],
       "extra-files": [
         "manifest.json"
-      ]
+      ],
+      "pull-request-header": "",
+      "pull-request-title-pattern": "Release v${version}"
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
## Summary
- Upgrade Release-Please to v4
- Fix YAML syntax error in build workflow
- Configure Release-Please to remove beep boop header

## Changes
- Updated release-please.yml to use googleapis/release-please-action@v4
- Fixed YAML syntax on line 35 of build-and-publish.yml by using multiline format
- Added pull-request-header and pull-request-title-pattern to release-please-config.json