### PR TITLE
fix: checkout develop branch in release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -47,10 +47,13 @@ jobs:
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git reset --hard  # Clear any uncommitted changes from npm install
-          git fetch origin develop
-          git checkout develop
+          # Fetch the develop branch explicitly
+          git fetch origin develop:refs/remotes/origin/develop
+          # Checkout develop tracking origin/develop
+          git checkout -b develop origin/develop
+          # Fast-forward merge master into develop
           git merge --ff-only origin/master
+          # Push the updated develop branch
           git push origin develop
 
   publish-chrome-store:


### PR DESCRIPTION
Attempts to fix the 'unrelated histories' error by properly checking out the existing develop branch from origin.