### PR TITLE
fix: remove npm install from build workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,6 +20,7 @@ jobs:
         id: release
         with:
           target-branch: master
+          config-file: release-please-config.json
           
       # The following steps only run if a release was created
       - uses: actions/checkout@v3
@@ -27,9 +28,7 @@ jobs:
       
       - name: Build Extension
         if: ${{ steps.release.outputs.release_created }}
-        run: |
-          npm install
-          npm run build
+        run: npm run build
       
       - name: Upload Release Asset
         if: ${{ steps.release.outputs.release_created }}
@@ -72,9 +71,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '18'
-      
-      - name: Install dependencies
-        run: npm install
       
       - name: Build extension
         run: npm run build


### PR DESCRIPTION
Build script only zips files, no dependencies needed