### PR TITLE
fix: keep highlight on the correct line when scrolling and navigating

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Lose track of how far you've read on a web page? Line Highlighter is a simple, privacy focused extension that highlights your current position on any website",
   "author": "Kyle Chadha",
   "scripts": {
-    "build": "rm -rf build && mkdir -p build && VERSION=$(grep '\"version\"' manifest.json | sed 's/.*\"version\": \"\\(.*\\)\".*/\\1/') && zip -r build/line-highlighter-v${VERSION}.zip manifest.json src/ assets/ -x '*.DS_Store' && echo \"Built: build/line-highlighter-v${VERSION}.zip\"",
+    "build": "rm -rf build && mkdir -p build && VERSION=$(grep '\"version\"' manifest.json | sed 's/.*\"version\": \"\\(.*\\)\".*/\\1/') && zip -r build/line-highlighter-v${VERSION}.zip manifest.json src/ assets/ -x '*.DS_Store' 'assets/demo.gif' && echo \"Built: build/line-highlighter-v${VERSION}.zip\"",
     "release": "./scripts/release.sh",
     "version": "echo Current version: $(grep '\"version\"' manifest.json | sed 's/.*\"version\": \"\\(.*\\)\".*/\\1/')",
     "test": "playwright test",

--- a/src/background.js
+++ b/src/background.js
@@ -39,6 +39,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     chrome.tabs.sendMessage(tabId, {
       type: 'setEnabled',
       enabled: message.enabled
+    }).catch(() => {
+      // No content script in this tab (chrome:// page, web store, or a tab
+      // opened before the extension loaded). Safe to ignore.
     });
   } else if (message.type === 'getCommands') {
     // Popup is asking for Chrome commands
@@ -90,6 +93,9 @@ chrome.commands.onCommand.addListener((command, tab) => {
     chrome.tabs.sendMessage(tab.id, {
       type: 'setEnabled',
       enabled: newState
+    }).catch(() => {
+      // No content script in this tab (chrome:// page, web store, or a tab
+      // opened before the extension loaded). Safe to ignore.
     });
   }
 });

--- a/src/content-script.js
+++ b/src/content-script.js
@@ -3,12 +3,8 @@
 
   let state = {
     enabled: false,
-    currentLineElement: null,
-    currentLineRect: null,
     textLines: [],
     currentLineIndex: -1,
-    currentPageY: 0,  // Track absolute page position
-    cursorPosition: 0,  // Track cursor position
     anchor: null  // { node, rectIndex } the line the bar is glued to
   };
 
@@ -131,7 +127,6 @@
     `;
 
     document.body.appendChild(highlighter);
-
   }
 
   function removeHighlighter() {
@@ -141,6 +136,8 @@
       highlighter = null;
     }
     state.anchor = null;
+    state.textLines = [];
+    state.currentLineIndex = -1;
   }
 
   function handleClick(e) {
@@ -151,16 +148,14 @@
       return;
     }
 
-    // Use pageY for absolute positioning
-    const lineInfo = findLineAtClick(e.clientX, e.clientY, e.pageX, e.pageY);
+    const lineInfo = findLineAtClick(e.clientX, e.clientY);
     if (lineInfo) {
-      state.currentPageY = lineInfo.pageY;
       positionHighlighter(lineInfo);
       scanTextLinesNearby(lineInfo);
     }
   }
 
-  function findLineAtClick(clientX, clientY, pageX, pageY) {
+  function findLineAtClick(clientX, clientY) {
     // Try caretPositionFromPoint first
     let caretPos = null;
     if (document.caretPositionFromPoint) {
@@ -198,8 +193,7 @@
               rect: rect,
               node: textNode,
               element: textNode.parentElement,
-              rectIndex: i,
-              pageY: pageY - clientY + rect.top + rect.height / 2
+              rectIndex: i
             };
           }
         }
@@ -234,8 +228,7 @@
           rect: closestRect,
           node: element,
           element: element,
-          rectIndex: closestIndex,
-          pageY: pageY - clientY + closestRect.top + closestRect.height / 2
+          rectIndex: closestIndex
         };
       }
     }
@@ -263,7 +256,9 @@
     const role = (element.getAttribute && element.getAttribute('role') || '').toLowerCase();
     if (role === 'navigation' || role === 'complementary') return true;
 
-    const raw = ((element.className || '') + ' ' + (element.id || '')).toString().toLowerCase();
+    // Use getAttribute('class') so SVG elements (className is an object there) work too.
+    const cls = (element.getAttribute && element.getAttribute('class')) || '';
+    const raw = (cls + ' ' + (element.id || '')).toLowerCase();
     const tokens = raw.split(/\s+/).filter(Boolean);
     return tokens.some(isNavToken);
   }
@@ -330,7 +325,7 @@
       textNodes.push(node);
     }
 
-    // Get line rects for all text nodes
+    // Get one entry per visible line rect across all text nodes
     const allLines = [];
     for (const textNode of textNodes) {
       const range = document.createRange();
@@ -340,23 +335,10 @@
       for (let i = 0; i < rects.length; i++) {
         const rect = rects[i];
         if (rect.height > 5 && rect.height < 100 && rect.width > 20) {
-          // Calculate absolute page position
-          const pageTop = window.pageYOffset + rect.top;
-
-          // Get the actual text content for this line to determine its real width
-          const textContent = textNode.textContent;
-          const textLength = textContent.trim().length;
-
           allLines.push({
-            rect: rect,
             node: textNode,
-            element: textNode.parentElement,
             rectIndex: i,
-            top: rect.top,
-            pageTop: pageTop,
-            left: rect.left,
-            width: rect.width,
-            textLength: textLength
+            pageTop: window.pageYOffset + rect.top  // absolute page position, for ordering
           });
         }
       }
@@ -401,7 +383,10 @@
   }
 
   // Live viewport rect for the anchored line, recomputed from the DOM so it stays
-  // correct through scrolling and reflow. Returns null if the line is gone.
+  // correct through scrolling. Returns null if the line is gone.
+  // Note: rectIndex is positional within the node's client rects, so a reflow that
+  // re-wraps the text (e.g. a window resize) can shift it to a different line. Scroll,
+  // the common case, never reflows, so tracking stays exact there.
   function rectForAnchor(anchor) {
     if (!anchor || !anchor.node || !anchor.node.isConnected) return null;
     const range = document.createRange();
@@ -446,10 +431,11 @@
     });
   }
 
+  // Glue the bar to a line and draw it. animate=true adds the glide/pulse used for
+  // click and keyboard moves; false snaps it (used while tracking scroll).
   function positionHighlighter(lineInfo, animate = false) {
     if (!highlighter || !lineInfo) return;
 
-    state.currentLineRect = lineInfo.rect;
     state.anchor = { node: lineInfo.node, rectIndex: lineInfo.rectIndex };
     renderHighlighter(animate);
   }
@@ -471,8 +457,7 @@
       const lineInfo = state.textLines[newIndex];
 
       // Glue the bar to the new line and glide to it
-      state.anchor = { node: lineInfo.node, rectIndex: lineInfo.rectIndex };
-      renderHighlighter(true);
+      positionHighlighter(lineInfo, true);
 
       // Scroll into view if needed. scrollIntoView walks every scrollable ancestor,
       // so it works whether the page scrolls the window or an inner container.
@@ -528,8 +513,6 @@
         console.log('Line Highlighter: Enabled - Click on text to highlight');
       } else {
         removeHighlighter();
-        state.textLines = [];
-        state.currentLineIndex = -1;
         console.log('Line Highlighter: Disabled');
       }
 
@@ -544,8 +527,9 @@
 
     if (!state.enabled) return;
 
-    // Don't hijack keys while the user is typing in a field
-    const target = e.target;
+    // Don't hijack keys while the user is typing in a field. composedPath()[0]
+    // sees the real target even inside a shadow root (e.target is retargeted).
+    const target = (e.composedPath && e.composedPath()[0]) || e.target;
     if (target && (target.isContentEditable ||
         /^(INPUT|TEXTAREA|SELECT)$/.test(target.tagName))) {
       return;

--- a/src/content-script.js
+++ b/src/content-script.js
@@ -8,7 +8,8 @@
     textLines: [],
     currentLineIndex: -1,
     currentPageY: 0,  // Track absolute page position
-    cursorPosition: 0  // Track cursor position
+    cursorPosition: 0,  // Track cursor position
+    anchor: null  // { node, rectIndex } the line the bar is glued to
   };
 
   // Default settings
@@ -22,14 +23,25 @@
   };
 
   let highlighter = null;
+  let rafPending = false;
+
+  // Transition with a vertical glide, used for click/keyboard moves
+  const TRANSITION_MOVE = 'top 0.12s cubic-bezier(0.25, 0.46, 0.45, 0.94), height 0.12s cubic-bezier(0.25, 0.46, 0.45, 0.94), transform 0.12s cubic-bezier(0.25, 0.46, 0.45, 0.94), opacity 0.1s ease-out';
+  // Transition without top/height glide, used while tracking scroll (1:1 follow)
+  const TRANSITION_TRACK = 'transform 0.12s cubic-bezier(0.25, 0.46, 0.45, 0.94), opacity 0.1s ease-out';
 
   async function init() {
     // Load settings from storage with fallback
     await loadSettings();
-    
+
     document.addEventListener('click', handleClick);
     document.addEventListener('keydown', handleKeydown);
-    
+
+    // Keep the bar glued to its line when the page (or an inner container) scrolls.
+    // Capture phase catches scroll events from inner scrollable containers, which do not bubble.
+    window.addEventListener('scroll', scheduleRender, true);
+    window.addEventListener('resize', scheduleRender);
+
     // Listen for settings changes from popup
     chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       if (message.type === 'updateSettings') {
@@ -66,13 +78,13 @@
       // Use defaults on error
     }
   }
-  
+
   function validateSettings(settings) {
     // Check if settings has the required structure
     if (!settings || typeof settings !== 'object') return false;
     if (!settings.shortcuts || typeof settings.shortcuts !== 'object') return false;
     if (!settings.color || typeof settings.color !== 'string') return false;
-    
+
     // Check each shortcut
     const requiredShortcuts = ['toggle', 'up', 'down'];
     for (const shortcut of requiredShortcuts) {
@@ -81,7 +93,7 @@
       if (!s.key || typeof s.key !== 'string') return false;
       if (!Array.isArray(s.modifiers)) return false;
     }
-    
+
     return true;
   }
 
@@ -102,11 +114,11 @@
 
   function createHighlighter() {
     if (highlighter) return;
-    
+
     highlighter = document.createElement('div');
     highlighter.id = 'line-highlighter-marker';
     highlighter.style.cssText = `
-      position: absolute;
+      position: fixed;
       left: 0;
       width: 100%;
       height: 24px;
@@ -115,11 +127,11 @@
       pointer-events: none;
       z-index: 2147483647;
       display: none;
-      transition: top 0.12s cubic-bezier(0.25, 0.46, 0.45, 0.94), height 0.12s cubic-bezier(0.25, 0.46, 0.45, 0.94), transform 0.12s cubic-bezier(0.25, 0.46, 0.45, 0.94), opacity 0.1s ease-out;
+      transition: ${TRANSITION_TRACK};
     `;
-    
+
     document.body.appendChild(highlighter);
-    
+
   }
 
   function removeHighlighter() {
@@ -128,16 +140,17 @@
       highlighter.remove();
       highlighter = null;
     }
+    state.anchor = null;
   }
 
   function handleClick(e) {
     if (!state.enabled) return;
-    
+
     // Don't process clicks on our own elements
     if (e.target.id === 'line-highlighter-marker' || e.target.id === 'line-highlighter-cursor') {
       return;
     }
-    
+
     // Use pageY for absolute positioning
     const lineInfo = findLineAtClick(e.clientX, e.clientY, e.pageX, e.pageY);
     if (lineInfo) {
@@ -161,36 +174,38 @@
         };
       }
     }
-    
+
     // If we got a caret position, use it
     if (caretPos && caretPos.offsetNode) {
-      const textNode = caretPos.offsetNode.nodeType === Node.TEXT_NODE 
-        ? caretPos.offsetNode 
+      const textNode = caretPos.offsetNode.nodeType === Node.TEXT_NODE
+        ? caretPos.offsetNode
         : caretPos.offsetNode.childNodes[caretPos.offset];
-      
+
       if (textNode && textNode.nodeType === Node.TEXT_NODE) {
         // Create a range for just the clicked line
         const range = document.createRange();
         range.selectNodeContents(textNode);
-        
+
         // Get all line rectangles for this text node
         const rects = Array.from(range.getClientRects());
-        
+
         // Find the specific line that was clicked
-        for (const rect of rects) {
-          if (clientY >= rect.top && clientY <= rect.bottom && 
+        for (let i = 0; i < rects.length; i++) {
+          const rect = rects[i];
+          if (clientY >= rect.top && clientY <= rect.bottom &&
               clientX >= rect.left && clientX <= rect.right) {
             return {
               rect: rect,
               node: textNode,
               element: textNode.parentElement,
+              rectIndex: i,
               pageY: pageY - clientY + rect.top + rect.height / 2
             };
           }
         }
       }
     }
-    
+
     // Fallback: find the closest text element
     const element = document.elementFromPoint(clientX, clientY);
     if (element && element.textContent && element.textContent.trim()) {
@@ -198,73 +213,67 @@
       const range = document.createRange();
       range.selectNodeContents(element);
       const rects = Array.from(range.getClientRects());
-      
+
       // Find closest line rect
       let closestRect = null;
+      let closestIndex = -1;
       let minDistance = Infinity;
-      
-      for (const rect of rects) {
+
+      for (let i = 0; i < rects.length; i++) {
+        const rect = rects[i];
         const distance = Math.abs(clientY - (rect.top + rect.height / 2));
         if (distance < minDistance) {
           minDistance = distance;
           closestRect = rect;
+          closestIndex = i;
         }
       }
-      
+
       if (closestRect && minDistance < 50) { // Within 50px of a line
         return {
           rect: closestRect,
           node: element,
           element: element,
+          rectIndex: closestIndex,
           pageY: pageY - clientY + closestRect.top + closestRect.height / 2
         };
       }
     }
-    
+
     return null;
   }
 
-  function getElementLineInfo(element, clientY, pageY) {
-    if (!element) return null;
-    
-    // Get all text nodes within this element
-    const walker = document.createTreeWalker(
-      element,
-      NodeFilter.SHOW_TEXT,
-      {
-        acceptNode: (node) => {
-          return node.textContent.trim() ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT;
-        }
-      }
+  // Class/id tokens that mark an element as page chrome (nav, sidebar, TOC) rather
+  // than content. Matched per whitespace-delimited class token so color/utility
+  // tokens like Tailwind's "bg-nav-bg-paper" do not trip a naive substring check.
+  const NAV_KEYWORDS = ['nav', 'navbar', 'navigation', 'sidebar', 'breadcrumb', 'breadcrumbs', 'toc'];
+
+  function isNavToken(token) {
+    return NAV_KEYWORDS.some((k) =>
+      token === k ||
+      token.startsWith(k + '-') || token.startsWith(k + '_') ||
+      token.endsWith('-' + k) || token.endsWith('_' + k)
     );
-    
-    let textNode;
-    while (textNode = walker.nextNode()) {
-      const range = document.createRange();
-      range.selectNodeContents(textNode);
-      const rects = Array.from(range.getClientRects());
-      
-      for (const rect of rects) {
-        if (clientY >= rect.top && clientY <= rect.bottom) {
-          return {
-            rect: rect,
-            node: textNode,
-            element: textNode.parentElement,
-            pageY: pageY - clientY + rect.top + rect.height / 2
-          };
-        }
-      }
-    }
-    
-    return null;
+  }
+
+  function isNavLike(element) {
+    if (!element || !element.tagName) return false;
+    if (element.tagName === 'NAV' || element.tagName === 'ASIDE') return true;
+
+    const role = (element.getAttribute && element.getAttribute('role') || '').toLowerCase();
+    if (role === 'navigation' || role === 'complementary') return true;
+
+    const raw = ((element.className || '') + ' ' + (element.id || '')).toString().toLowerCase();
+    const tokens = raw.split(/\s+/).filter(Boolean);
+    return tokens.some(isNavToken);
   }
 
   function scanTextLinesNearby(currentLine) {
     state.textLines = [];
     state.currentLineIndex = -1;
-    
+
     if (!currentLine || !currentLine.element) return;
-    
+
     // Get the parent container - go higher up to catch all content
     let container = currentLine.element;
     let attempts = 0;
@@ -272,13 +281,13 @@
       container = container.parentElement;
       attempts++;
     }
-    
+
     // If we're in an article, make sure we get the whole article
     const article = container.closest('article');
     if (article) {
       container = article;
     }
-    
+
     // Find all text nodes in the container
     const walker = document.createTreeWalker(
       container,
@@ -287,70 +296,62 @@
         acceptNode: (node) => {
           const text = node.textContent.trim();
           if (text.length < 2) return NodeFilter.FILTER_REJECT;
-          
+
           const parent = node.parentElement;
           if (!parent) return NodeFilter.FILTER_REJECT;
-          
+
           const style = window.getComputedStyle(parent);
           if (style.display === 'none' || style.visibility === 'hidden') {
             return NodeFilter.FILTER_REJECT;
           }
-          
+
           // Skip if parent is script or style
           if (parent.tagName === 'SCRIPT' || parent.tagName === 'STYLE') {
             return NodeFilter.FILTER_REJECT;
           }
-          
-          // Skip navigation, sidebar, and breadcrumb elements
+
+          // Skip navigation, sidebar, breadcrumb, and TOC elements
           let checkElement = parent;
           while (checkElement && checkElement !== document.body) {
-            const className = checkElement.className || '';
-            const id = checkElement.id || '';
-            const combined = (className + ' ' + id).toLowerCase();
-            
-            if (combined.includes('sidebar') || 
-                combined.includes('breadcrumb') || 
-                combined.includes('navigation') ||
-                combined.includes('nav-') ||
-                combined.includes('toc') ||
-                checkElement.tagName === 'NAV' ||
-                checkElement.tagName === 'ASIDE') {
+            if (isNavLike(checkElement)) {
               return NodeFilter.FILTER_REJECT;
             }
             checkElement = checkElement.parentElement;
           }
-          
+
           return NodeFilter.FILTER_ACCEPT;
         }
       }
     );
-    
+
     const textNodes = [];
     let node;
     while (node = walker.nextNode()) {
       textNodes.push(node);
     }
-    
+
     // Get line rects for all text nodes
     const allLines = [];
     for (const textNode of textNodes) {
       const range = document.createRange();
       range.selectNodeContents(textNode);
       const rects = Array.from(range.getClientRects());
-      
-      for (const rect of rects) {
+
+      for (let i = 0; i < rects.length; i++) {
+        const rect = rects[i];
         if (rect.height > 5 && rect.height < 100 && rect.width > 20) {
           // Calculate absolute page position
           const pageTop = window.pageYOffset + rect.top;
-          
+
           // Get the actual text content for this line to determine its real width
           const textContent = textNode.textContent;
           const textLength = textContent.trim().length;
-          
+
           allLines.push({
             rect: rect,
             node: textNode,
             element: textNode.parentElement,
+            rectIndex: i,
             top: rect.top,
             pageTop: pageTop,
             left: rect.left,
@@ -360,29 +361,29 @@
         }
       }
     }
-    
+
     // Sort by vertical position
     allLines.sort((a, b) => a.pageTop - b.pageTop);
-    
+
     // Remove duplicates (lines at same position)
     state.textLines = allLines.filter((line, index) => {
       if (index === 0) return true;
       const prev = allLines[index - 1];
       return Math.abs(line.pageTop - prev.pageTop) > 2;
     });
-    
-    // Find current line index
-    const currentPageTop = window.pageYOffset + currentLine.rect.top;
+
+    // Find current line index by the exact node + line clicked
     for (let i = 0; i < state.textLines.length; i++) {
       const line = state.textLines[i];
-      if (Math.abs(line.pageTop - currentPageTop) < 5) {
+      if (line.node === currentLine.node && line.rectIndex === currentLine.rectIndex) {
         state.currentLineIndex = i;
         break;
       }
     }
-    
-    // If we didn't find exact match, find closest
+
+    // If we didn't find exact match, find closest by page position
     if (state.currentLineIndex === -1 && state.textLines.length > 0) {
+      const currentPageTop = window.pageYOffset + currentLine.rect.top;
       let minDistance = Infinity;
       for (let i = 0; i < state.textLines.length; i++) {
         const distance = Math.abs(state.textLines[i].pageTop - currentPageTop);
@@ -399,16 +400,28 @@
     return ['article', 'main', 'body', 'section'].includes(tag);
   }
 
-  function positionHighlighter(lineInfo, animate = false) {
-    if (!highlighter || !lineInfo) return;
-    
-    const rect = lineInfo.rect;
-    state.currentLineRect = rect;
-    
-    // Use absolute positioning with pageY
-    const pageTop = window.pageYOffset + rect.top;
-    
-    // Add subtle scale and fade effects during animation
+  // Live viewport rect for the anchored line, recomputed from the DOM so it stays
+  // correct through scrolling and reflow. Returns null if the line is gone.
+  function rectForAnchor(anchor) {
+    if (!anchor || !anchor.node || !anchor.node.isConnected) return null;
+    const range = document.createRange();
+    range.selectNodeContents(anchor.node);
+    const rects = range.getClientRects();
+    return rects[anchor.rectIndex] || null;
+  }
+
+  // Draw the bar at its anchor's current on-screen position (position: fixed = viewport coords).
+  function renderHighlighter(animate) {
+    if (!highlighter || !state.anchor) return;
+
+    const rect = rectForAnchor(state.anchor);
+    if (!rect) {
+      highlighter.style.display = 'none';
+      return;
+    }
+
+    highlighter.style.transition = animate ? TRANSITION_MOVE : TRANSITION_TRACK;
+
     if (animate) {
       highlighter.style.transform = 'scaleY(1.02)';
       highlighter.style.opacity = '0.7';
@@ -417,60 +430,60 @@
         highlighter.style.opacity = '1';
       }, 150);
     }
-    
-    highlighter.style.top = `${pageTop}px`;
+
+    highlighter.style.top = `${rect.top}px`;
     highlighter.style.height = `${rect.height}px`;
     highlighter.style.display = 'block';
+  }
+
+  // Throttle scroll/resize repositioning to one update per frame.
+  function scheduleRender() {
+    if (rafPending) return;
+    rafPending = true;
+    requestAnimationFrame(() => {
+      rafPending = false;
+      renderHighlighter(false);
+    });
+  }
+
+  function positionHighlighter(lineInfo, animate = false) {
+    if (!highlighter || !lineInfo) return;
+
+    state.currentLineRect = lineInfo.rect;
+    state.anchor = { node: lineInfo.node, rectIndex: lineInfo.rectIndex };
+    renderHighlighter(animate);
   }
 
 
   function navigateToLine(direction) {
     if (state.textLines.length === 0) return;
-    
+
     let newIndex = state.currentLineIndex;
-    
+
     if (direction === 'up') {
       newIndex = Math.max(0, state.currentLineIndex - 1);
     } else {
       newIndex = Math.min(state.textLines.length - 1, state.currentLineIndex + 1);
     }
-    
+
     if (newIndex !== state.currentLineIndex && state.textLines[newIndex]) {
       state.currentLineIndex = newIndex;
       const lineInfo = state.textLines[newIndex];
-      
-      // Position using absolute page coordinates with animation
-      if (highlighter) {
-        // Add subtle scale and fade effects
-        highlighter.style.transform = 'scaleY(1.02)';
-        highlighter.style.opacity = '0.7';
-        
-        setTimeout(() => {
-          highlighter.style.transform = 'scaleY(1)';
-          highlighter.style.opacity = '1';
-        }, 150);
-        
-        highlighter.style.top = `${lineInfo.pageTop}px`;
-        highlighter.style.height = `${lineInfo.rect.height}px`;
-        highlighter.style.display = 'block';
-      }
-      
-      // Scroll if necessary - only if line is not fully visible
-      const rect = lineInfo.rect;
-      const scrollTop = window.pageYOffset;
-      const viewportTop = scrollTop;
-      const viewportBottom = scrollTop + window.innerHeight;
-      const lineTop = lineInfo.pageTop;
-      const lineBottom = lineInfo.pageTop + rect.height;
-      
-      // Only scroll if line is not fully visible in viewport
-      if (lineTop < viewportTop + 50 || lineBottom > viewportBottom - 50) {
-        // Calculate scroll to center the line
-        const targetScroll = lineInfo.pageTop - (window.innerHeight / 2);
-        window.scrollTo({
-          top: targetScroll,
-          behavior: 'smooth'
-        });
+
+      // Glue the bar to the new line and glide to it
+      state.anchor = { node: lineInfo.node, rectIndex: lineInfo.rectIndex };
+      renderHighlighter(true);
+
+      // Scroll into view if needed. scrollIntoView walks every scrollable ancestor,
+      // so it works whether the page scrolls the window or an inner container.
+      const rect = rectForAnchor(state.anchor);
+      if (rect && (rect.top < 60 || rect.bottom > window.innerHeight - 60)) {
+        const target = lineInfo.node.nodeType === Node.ELEMENT_NODE
+          ? lineInfo.node
+          : lineInfo.node.parentElement;
+        if (target) {
+          target.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        }
       }
     }
   }
@@ -495,12 +508,12 @@
 
   function matchesShortcut(e, shortcut) {
     const keyMatches = e.key.toLowerCase() === shortcut.key.toLowerCase();
-    
+
     // Check that modifiers match exactly
     const altMatches = shortcut.modifiers.includes('alt') === e.altKey;
     const ctrlMatches = shortcut.modifiers.includes('ctrl') === (e.ctrlKey || e.metaKey);
     const shiftMatches = shortcut.modifiers.includes('shift') === e.shiftKey;
-    
+
     return keyMatches && altMatches && ctrlMatches && shiftMatches;
   }
 
@@ -509,7 +522,7 @@
     if (matchesShortcut(e, settings.shortcuts.toggle)) {
       e.preventDefault();
       state.enabled = !state.enabled;
-      
+
       if (state.enabled) {
         createHighlighter();
         console.log('Line Highlighter: Enabled - Click on text to highlight');
@@ -519,18 +532,25 @@
         state.currentLineIndex = -1;
         console.log('Line Highlighter: Disabled');
       }
-      
+
       // Notify background script to update icon
       chrome.runtime.sendMessage({
         type: 'stateChanged',
         enabled: state.enabled
       });
-      
+
       return;
     }
-    
+
     if (!state.enabled) return;
-    
+
+    // Don't hijack keys while the user is typing in a field
+    const target = e.target;
+    if (target && (target.isContentEditable ||
+        /^(INPUT|TEXTAREA|SELECT)$/.test(target.tagName))) {
+      return;
+    }
+
     // Handle navigation with custom shortcuts
     if (matchesShortcut(e, settings.shortcuts.up)) {
       e.preventDefault();

--- a/tests/core-tests.spec.js
+++ b/tests/core-tests.spec.js
@@ -73,15 +73,43 @@ test.describe('Core Tests - Manifest and Build', () => {
 
   test('test helpers should work correctly', () => {
     const { getToggleShortcut, getNavigationShortcuts } = require('./test-helpers');
-    
+
     // Should return a shortcut
     const toggleShortcut = getToggleShortcut();
     expect(toggleShortcut).toBeTruthy();
     expect(toggleShortcut).toContain('+');
-    
+
     // Should return navigation shortcuts
     const navShortcuts = getNavigationShortcuts();
     expect(navShortcuts.up).toBe('f');
     expect(navShortcuts.down).toBe('v');
+  });
+});
+
+test.describe('Regression - content script fixes', () => {
+  const csPath = path.join(__dirname, '..', 'src', 'content-script.js');
+  const cs = fs.readFileSync(csPath, 'utf8');
+
+  test('highlight bar uses fixed positioning so it tracks scroll', () => {
+    // position:fixed + a live-rect recompute keeps the bar on its line when an
+    // inner container scrolls (window.pageYOffset stays 0 on those sites, so the
+    // old position:absolute + stored pageTop detached from the text).
+    expect(cs).toContain('position: fixed');
+    expect(cs).not.toContain('position: absolute');
+  });
+
+  test('scroll is tracked in capture phase to catch inner scroll containers', () => {
+    // Inner-container scroll events do not bubble; capture phase is required.
+    expect(cs).toMatch(/addEventListener\(\s*['"]scroll['"]\s*,\s*scheduleRender\s*,\s*true\s*\)/);
+    expect(cs).toContain("addEventListener('resize', scheduleRender)");
+  });
+
+  test('nav filter matches class tokens, not raw substrings', () => {
+    // Guards the bug where the Tailwind token "bg-nav-bg-paper" matched a naive
+    // "nav-" substring (and "protocol" matched "toc"), hiding all page text and
+    // breaking F/V navigation.
+    expect(cs).toContain('isNavLike');
+    expect(cs).not.toContain("includes('nav-')");
+    expect(cs).not.toContain("includes('toc')");
   });
 });


### PR DESCRIPTION
## Problem
On some sites (e.g. hellointerview.com) the highlighter had two bugs:

1. **F/V navigation did nothing.** The line scanner rejected any text whose ancestor class/id contained the substring `nav-`. A Tailwind color token, `bg-nav-bg-paper`, matched it, so every prose node was filtered out and `textLines` was empty. (The same raw-substring check also let `toc` match `protocol`.) Clicking still worked because it uses a different code path.
2. **The bar detached from its line on scroll.** hellointerview scrolls an inner `<main overflow-y-auto>`, so `window.pageYOffset` stays `0`. The bar was positioned with `position: absolute; top = pageYOffset + rect.top`, which never updated for inner-container scrolls, so the text scrolled out from under the bar.

## Fix
- **Nav filter:** new `isNavLike()` helper matches nav/sidebar/breadcrumb/TOC by whitespace-delimited class token (or `<nav>`/`<aside>` tag, or `role=navigation`/`complementary`), not raw substring. `bg-nav-bg-paper` and `protocol` no longer false-match
- **Scroll tracking:** the bar now anchors to the line's DOM node + line index, uses `position: fixed`, and recomputes the line's live `getClientRects()` rect on scroll (capture phase, so inner-container scrolls are caught) and resize. F/V navigation uses `scrollIntoView`, which handles inner scroll containers too
- **Typing guard:** skip F/V navigation while focus is in an input/textarea/contenteditable

## Verification
- `npm test` passes (5/5)
- Verified live on hellointerview.com via browser automation:
  - Content lines found: **379** (was 0)
  - Prose accepted, real `<nav>` rejected, `bg-nav-bg-paper` no longer a false positive
  - Confirmed the inner scroller is `<main overflow-y-auto>` and a line's `getClientRects().top` tracks the inner scroll 1:1 (the premise the fix relies on)

## Notes
- Removed dead `getElementLineInfo()` (never called)